### PR TITLE
Move more PAVE stuff out of XC.5 (Weather) and into XC.7 (go/no-go).

### DIFF
--- a/Filed/Complete VFR Preflight Checklist.md
+++ b/Filed/Complete VFR Preflight Checklist.md
@@ -2,7 +2,7 @@ This is a complete list of all preflight actions and checks (everything the pilo
 
 ## Pilot
 - [ ] [[IMSAFE|I.M.S.A.F.E.]]
-- [ ] Government-Issued ID, Pilot License, and Medical Certificate in your possession (§ [[FAR 61.3|61.3]])
+- [ ] Government-Issued ID, Pilot License, and Medical Certificate[^med] in your possession (§ [[FAR 61.3|61.3]])
 	- [ ] If on a solo, logbook with solo endorsement (§ [[FAR 61.3|61.3]])
 - [ ] Checkride or Flight Review in the past 24 months (§ [[FAR 61.56 Flight Review|61.56]])
 - [ ] Recent Flight Experience for carrying passengers (§ [[FAR 61.57 Recent Flight Experience|61.57]])
@@ -11,7 +11,7 @@ This is a complete list of all preflight actions and checks (everything the pilo
 - [ ] Overall, the PIC is responsible for verifying airworthiness (§ 91.7, § 91.403)
 - [ ] [[AR(R)OW]] (§ 91.9, § 91.203)
 - [ ] Seat adjusted, cabin organized
-- [ ] POH-specific preflight inspection completed
+- [ ] POH-specific preflight inspection completed[^insp]
 - [ ] Weight and Balance within limits
 - [ ] Confirm sufficient fuel, with reserves
 - [ ] All required equipment operational
@@ -49,3 +49,17 @@ This is a complete list of all preflight actions and checks (everything the pilo
 
 > [!tip]
 > Structure for this is based on [[PAVE]].
+
+
+[^insp]: Any preflight inspection will include verifying the following:
+  . Primary/Secondary flight controls
+  . Powerplant and propeller
+  . Landing gear
+  . Fuel, oil, and hydraulic
+  . Electrical
+  . Avionics
+  . Pitot-static, vacuum/pressure, and associated flight instruments
+  . Environmental
+  . Deicing and anti-icing
+  
+[^med]: See also [[Medical Requirements]]

--- a/Filed/Pilot Currency to be Legal.md
+++ b/Filed/Pilot Currency to be Legal.md
@@ -1,3 +1,0 @@
-1. To carry passengers, 3 take offs/landings in last 90 days (§ [[FAR 61.57 Recent Flight Experience|61.57]])
-2. To carry passengers at night, 3 takeoffs/landings in last 90 days at night (1hr after sunset, 1hr before sunrise to full stop) (§ [[FAR 61.57 Recent Flight Experience|61.57]])
-3. BFR (flight review with instructor) or checkride, within the last 24 months (§ [[FAR 61.56 Flight Review|61.56]])

--- a/Filed/Pilot Documents to be Legal.md
+++ b/Filed/Pilot Documents to be Legal.md
@@ -1,6 +1,0 @@
-1. Pilot Certificate
-2. Medical
-3. Gov't Issued Photo ID
-
-#todo :: Link to relevant FAR
-

--- a/Lesson Plans/Private/XC.5 Advanced Weather Briefs and Preflight Planning.md
+++ b/Lesson Plans/Private/XC.5 Advanced Weather Briefs and Preflight Planning.md
@@ -3,7 +3,7 @@ cssclass: lesson
 tags: ppl, lesson
 ---
 ### Objective
-Develop ability to obtain, process and understand pre-flight weather briefings, and use weather data. Understand services and process intended to help identify risks and make better decisions.
+Develop ability to obtain, process and understand pre-flight weather briefings, and use weather data. 
 
 ### Resources
 - [[Private Pilot ACS]] Sections I.C, I.D
@@ -27,70 +27,38 @@ Ground 1.5 hour, practice on multiple flights
 > 
 > ![[XC Syllabus Topics On Flight Plan.pdf]]
 
-1. [[PAVE]] and [[NWKRAFT]]
-	1. Pilot
-		1. Medical
-			1. [[Medical Requirements]]
-			2. [[Human Factors]]
-		3. Legal & Current
-			1. [[Pilot Currency to be Legal]]
-			2. [[Pilot Documents to be Legal]]
-		4. Proficiency
-		5. [[5 Hazardous Attitudes and Antidotes]]
-		6. [[Personal Minimums]] and [[ADM]]
-	2. Aircraft
-		1. Required equipment ([[A GOOSE A CAT]] or [[A TOMATO FLAMES]])
-		2. Required inspections ([[AAV1ATE]])
-		3. Equipment and Preflight
-			1. Primary/Secondary flight controls
-			2. Powerplant and propeller
-			3. Landing gear
-			4. Fuel, oil, and hydraulic
-			5. Electrical
-			6. Avionics
-			7. Pitot-static, vacuum/pressure, and associated flight instruments
-			8. Environmental
-			9. Deicing and anti-icing
-		4. How to share expenses? [[AC 61-142]] and [[FAR 61.113 Private Pilot Privileges and Limitations]]
-	3. Environment
-		1. Weather
-			1. Weather theory -- see [[Aviation Weather Handbook]] for best resources
-				1. Air Masses and Fronts
-					1. [[Winds Around Pressure Systems.jpeg]]
-					2. [[Isobars Reveal Pressure Gradient.jpeg]]
-					3. Warm, Cold, Stationary, and Occluded Fronts
-				2. Atmospheric Stability ([[Temp Lapse Rates Effect on Stability.jpeg]]^[The 3°C per 1000ft is the dry adiabatic lapse rate and 0.5°C is the dew point lapse rate, used in this image. See Chap 12/13 of [[Aviation Weather Handbook]] for more info.])
-					1. "As air ascends through the atmosphere, the average rate of temperature change is 2 °C (3.5 °F) per 1,000 feet." - [[PHAK Ch12]]
-					2. [[Convective Turbulence Avoidance.jpeg]]
-				4. Recognizing [[thunderstorm]]s, [[wind shear]], [[Ice Hazards and Aircraft Icing|ice]], and other critical weather situations
-			2. Weather briefings in depth
-				1. Structure of weather briefings
-				2. Adverse conditions: [[TFR]]s, [[NOTAM]]s, [[SIGMET]]s, [[AIRMET]]s, etc.
-				3. Current weather
-				4. Forecasts: Area, [[TAF]]s, [[Winds Aloft]], [[MOS]]
-			3. Types of [[weather brief|weather briefings]] from Flight Service
-				1. Outlook
-				2. Standard
-				3. Abbreviated
-		2. Flight Services Enroute
-		3. [[VFR]] flight plans for search and rescue
-			1. When to use them
-			2. How to file
-			3. How to activate and close
-		4. Estimating visibility in flight^[Some suggestions from [[AOPA]] in [this article](https://www.aopa.org/news-and-media/all-news/2008/april/flight-training-magazine/basic-vfr)]
-		5. Airport: preparation discussed in [[XC.2 Advanced Airport Operations]]
-	4. External Pressures
-		1. How to identify
-		2. How to mitigate
-		3. [[Personal Minimums]]
+1. Weather and Weather Briefings
+	1. Weather theory -- see [[Aviation Weather Handbook]] for best resources
+		1. Air Masses and Fronts
+			1. [[Winds Around Pressure Systems.jpeg]]
+			2. [[Isobars Reveal Pressure Gradient.jpeg]]
+			3. Warm, Cold, Stationary, and Occluded Fronts
+		2. Atmospheric Stability ([[Temp Lapse Rates Effect on Stability.jpeg]]^[The 3°C per 1000ft is the dry adiabatic lapse rate and 0.5°C is the dew point lapse rate, used in this image. See Chap 12/13 of [[Aviation Weather Handbook]] for more info.])
+			1. "As air ascends through the atmosphere, the average rate of temperature change is 2 °C (3.5 °F) per 1,000 feet." - [[PHAK Ch12]]
+			2. [[Convective Turbulence Avoidance.jpeg]]
+		3. Recognizing [[thunderstorm]]s, [[wind shear]], [[Ice Hazards and Aircraft Icing|ice]], and other critical weather situations
+	2. Weather briefings in depth
+		1. Structure of weather briefings
+		2. Adverse conditions: [[TFR]]s, [[NOTAM]]s, [[SIGMET]]s, [[AIRMET]]s, etc.
+		3. Current weather
+		4. Forecasts: Area, [[TAF]]s, [[Winds Aloft]], [[MOS]]
+	3. Types of [[weather brief|weather briefings]] from Flight Service
+		1. Outlook
+		2. Standard
+		3. Abbreviated
+2. Other topics related to cross-country planning and flying:
+	1. [[Human Factors]]
+	2. How to share expenses? [[AC 61-142]] and [[FAR 61.113 Private Pilot Privileges and Limitations]]
+	3. Flight Services Enroute
+	4. [[VFR]] flight plans for search and rescue
+		1. When to use them
+		2. How to file
+		3. How to activate and close
+	5. Estimating visibility in flight^[Some suggestions from [[AOPA]] in [this article](https://www.aopa.org/news-and-media/all-news/2008/april/flight-training-magazine/basic-vfr)]
 
-
-> [!note]
-> The sections above overlap heavily with the [[Complete VFR Preflight Checklist]]
-> 
 
 ### Completion Standards
-Learner should develop working knowledge of weather theory, and understand sources of weather information for pre-flight planning. Learner creates their personal minimums.
+Learner should develop working knowledge of weather theory, and understand sources of weather information for pre-flight planning.
 
 ### Required Logbook Phraseology
 For [[FAR 61.93 Solo XC Reqs]]:

--- a/Lesson Plans/Private/XC.7 Making the Go-No-Go Decision.md
+++ b/Lesson Plans/Private/XC.7 Making the Go-No-Go Decision.md
@@ -3,7 +3,7 @@ cssclass: lesson
 tags: ppl, lesson
 ---
 ### Objective
-xxx
+....Understand services and process intended to help identify risks and make better decisions.
 
 ### Resources
 - yyy
@@ -17,11 +17,10 @@ xxx
 Ground X hours, Y hour sim/flight
 
 ### Lesson Elements
-> [!info]- Structure of XC Lessons...
-> Lessons PPL [[XC.2 Advanced Airport Operations|18]], [[XC.3 Flight Planning, Navigation Systems, and Other XC Equipment|19]], [[XC.4 Aircraft Performance and Weight+Balance|20]], [[XC.5 Advanced Weather Briefs and Preflight Planning|21]], & [[XC.6 Pilotage and Dead Reckoning|22]] can be thought of as building out each part of a flight plan.
-> 
-> ![[XC Syllabus Topics On Flight Plan.pdf]]
-
+WORK IN PROGRESS
+A few things to cover:
+- [[5 Hazardous Attitudes and Antidotes]]
+- [[Complete VFR Preflight Checklist]]
 
 ### Completion Standards
 qqq
@@ -31,7 +30,7 @@ For [[FAR 61.93 Solo XC Reqs]]:
 - yyy
 
 ### Required Homework
-- [ ] aaa
+- [ ]  Learner creates their personal minimums.
 
 ### Recommended Homework 
 - [ ] bbb


### PR DESCRIPTION
There were some topics in XC.5 that weren't really weather, but weren't go/no-go either.  I moved those to the end of XC.5, in an "other topics" section, so they aren't lost.

XC.7 (go/no-go) still needs to be filled out.