### PR TITLE
Added specific FAR references for each phraseology

### DIFF
--- a/Lesson Plans/Private/PPL1.1 Aircraft Preflight, Taxiing, and Postflight Procedures.md
+++ b/Lesson Plans/Private/PPL1.1 Aircraft Preflight, Taxiing, and Postflight Procedures.md
@@ -70,11 +70,13 @@ N/A
 > The 'Preflight' section above is a simplified version of the [[Complete VFR Preflight Checklist]].
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]] and [[FAR 61.107 PPL Flight Reqs]]: 
-- Taxiing or surface operations, including runups
-- Proper flight preparation procedures, including... powerplant operation, and aircraft systems
-- Preflight procedures
-- Postflight procedures
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(1) Proper flight preparation procedures, including...^[remaining items covered in [[PPL1.3 Weather Briefs and Preflight Planning]]] powerplant operation, and aircraft systems
+- (d)(2) Taxiing or surface operations, including runups
+
+[[FAR 61.107 PPL Flight Reqs]]:
+- (b)(1)(ii) Preflight procedures
+- (b)(1)(xii) Postflight procedures
 
 ### Completion Standards
 Learner must become proficient at preflight aircraft inspection, engine start, before takeoff check, and post-flight procedures.

--- a/Lesson Plans/Private/PPL1.2 Four Fundamentals of Flight.md
+++ b/Lesson Plans/Private/PPL1.2 Four Fundamentals of Flight.md
@@ -98,10 +98,10 @@ Learner must demonstrate ability to use external visual references to maintain a
 > ±10 knots, ±10° degrees, ±100 feet^[These are a reasonable blend of minimums from other ACS standards, since four fundamentals is assessed as part of other maneuvers in the checkride.]
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]]: 
-- Straight and level flight, and turns in both directions;
-- Climbs and climbing turns;
-- Descents, with and without turns, using high and low drag configurations;
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(4) Straight and level flight, and turns in both directions;
+- (d)(5) Climbs and climbing turns;
+- (d)(8) Descents, with and without turns, using high and low drag configurations;
 
 ### Required Homework
 None

--- a/Lesson Plans/Private/PPL1.3 Weather Briefs and Preflight Planning.md
+++ b/Lesson Plans/Private/PPL1.3 Weather Briefs and Preflight Planning.md
@@ -49,9 +49,11 @@ Develop initial knowledge of and sources for preflight briefings.
 Learner completes first pre-flight briefing, and is able to complete a briefing for all future flights.
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]] and [[FAR 61.107 PPL Flight Reqs]]: 
-- Proper flight preparation procedures, including preflight planning and preparation...
-- Preflight preparation
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(1) Proper flight preparation procedures, including preflight planning and preparation...^[remaining items covered in [[PPL1.1 Aircraft Preflight, Taxiing, and Postflight Procedures]]]
+
+[[FAR 61.107 PPL Flight Reqs]]
+- (b)(1)(i) Preflight preparation
 
 ### Required Homework
 - [ ] Start using [1800wxbrief.com](https://www.1800wxbrief.com) for pre-flight briefings before every lesson

--- a/Lesson Plans/Private/PPL1.4 Normal and Crosswind Takeoffs and Climbs.md
+++ b/Lesson Plans/Private/PPL1.4 Normal and Crosswind Takeoffs and Climbs.md
@@ -63,8 +63,8 @@ Understand and become proficient at the procedures used for normal/crosswind tak
 	3. Drifting from centerline during climb out
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]]: 
-- Takeoffs, including normal and crosswind
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(3) Takeoffs^[Landings covered in [[PPL3.2 Normal and Crosswind Approaches and Landings]]], including normal and crosswind
 
 ### Completion Standards
 Client must demonstrate proficiency and safety for normal takeoffs and climbs, including pre-takeoff checks, traffic awareness, and emergency options.

--- a/Lesson Plans/Private/PPL1.5 Towered Airport Operations.md
+++ b/Lesson Plans/Private/PPL1.5 Towered Airport Operations.md
@@ -77,10 +77,14 @@ N/A
 Learner must demonstrate good radio communications and etiquette as specified in the AIM, understand the training airport ground environment, and how to use light signals in case of radio/electrical failure.
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]], [[FAR 61.105 PPL Knowledge Reqs]], and [[FAR 61.107 PPL Flight Reqs]]: 
-- Airport traffic patterns, including entry and departure procedures
-- Airport and seaplane base operations
-- Radio communication procedures
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(6) Airport traffic patterns, including entry and departure procedures
+
+[[FAR 61.105 PPL Knowledge Reqs]]:
+- (b)(5) Radio communication procedures
+
+[[FAR 61.107 PPL Flight Reqs]]:
+- (b)(1)(iii) Airport and seaplane base operations
 
 ### Required Homework
 - [ ] Memorize [[Phonetic Alphabet]] -- consider singing the alphabet while washing hands, or practicing license plates on drive

--- a/Lesson Plans/Private/PPL2.1 Slow Flight and Power-Off Stalls.md
+++ b/Lesson Plans/Private/PPL2.1 Slow Flight and Power-Off Stalls.md
@@ -105,11 +105,15 @@ Client must be able to demonstrate power-off stalls, to ACS standards.
 > Recovery no lower than 1500' AGL, heading ±10° before stall, or specified bank angle ±10° (and <20°), acknowledge cues of impending stall and recover promptly with proper procedure
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]], [[FAR 61.105 PPL Knowledge Reqs]], and [[FAR 61.107 PPL Flight Reqs]]: 
-- Flight at various airspeeds from cruise to slow flight
-- Stall entries from various flight attitudes and power combinations with recovery initiated at the first indication of a stall, and recovery from a full stall
-- Slow flight and stalls
-- Principles of aerodynamics...
+[[FAR 61.87 Student Solo Reqs]]:
+- (d)(9) Flight at various airspeeds from cruise to slow flight
+- (d)(10) Stall entries from various flight attitudes and power combinations with recovery initiated at the first indication of a stall, and recovery from a full stall^[Also covered in [[PPL2.3 Power-On Stalls and Spin Awareness]]]
+
+[[FAR 61.105 PPL Knowledge Reqs]], and : 
+- (b)(10) (partial) Principles of aerodynamics...
+
+[[FAR 61.107 PPL Flight Reqs]]
+- (b)(1)(viii) Slow flight and stalls
 
 ### Required Homework
  None

--- a/Lesson Plans/Private/PPL2.3 Power-On Stalls and Spin Awareness.md
+++ b/Lesson Plans/Private/PPL2.3 Power-On Stalls and Spin Awareness.md
@@ -86,9 +86,11 @@ Learner must be able to demonstrate power-on stalls, to ACS standards. The clien
 
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]] and [[FAR 61.105 PPL Knowledge Reqs]]: 
-- Stall entries from various flight attitudes and power combinations with recovery initiated at the first indication of a stall, and recovery from a full stall
-- Stall awareness, spin entry, spins, and spin recovery techniques for the airplane and glider category ratings
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(10) Stall entries from various flight attitudes and power combinations with recovery initiated at the first indication of a stall, and recovery from a full stall^[Also covered in [[PPL2.1 Slow Flight and Power-Off Stalls]]]
+
+[[FAR 61.105 PPL Knowledge Reqs]]
+- (b)(11) Stall awareness, spin entry, spins, and spin recovery techniques for the airplane and glider category ratings
 
 ### Required Homework
 None

--- a/Lesson Plans/Private/PPL2.4 Steep Turns.md
+++ b/Lesson Plans/Private/PPL2.4 Steep Turns.md
@@ -49,8 +49,8 @@ Client must demonstrate the ability to choose an appropriate location, select a 
 > ±100'; ±10kts; bank±5°; hdg±10°
 
 ### Required Logbook Phraseology
-For [[FAR 61.107 PPL Flight Reqs]]:
-- Performance maneuvers
+[[FAR 61.107 PPL Flight Reqs]]:
+- (b)(1)(v) Performance maneuvers
 
 ### Required Homework
  None

--- a/Lesson Plans/Private/PPL2.5 Ground Reference Maneuvers.md
+++ b/Lesson Plans/Private/PPL2.5 Ground Reference Maneuvers.md
@@ -65,8 +65,11 @@ Client must demonstrate the ability to choose an appropriate location, select a 
 > ±100'; ±10kts; constant radius
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]] and [[FAR 61.107 PPL Flight Reqs]]:
-- Ground reference maneuvers
+[[FAR 61.87 Student Solo Reqs]]:
+- (d)(12) Ground reference maneuvers
+
+[[FAR 61.107 PPL Flight Reqs]]
+- (b)(1)(vi) Ground reference maneuvers
 
 ### Required Homework
 None

--- a/Lesson Plans/Private/PPL2.6 Aircraft Systems.md
+++ b/Lesson Plans/Private/PPL2.6 Aircraft Systems.md
@@ -88,8 +88,8 @@ Learner understands the primary aircraft systems, how they work, and how they ca
 Learner understands impact of all preflight and runup checklist items, including which system is being tested and how.
 
 ### Required Logbook Phraseology
-For [[FAR 61.105 PPL Knowledge Reqs]]:
-- Principles of... powerplants, and aircraft systems
+[[FAR 61.105 PPL Knowledge Reqs]]:
+- (b)(10)  (partial) Principles of... powerplants, and aircraft systems
 
 ### Required Homework
 None

--- a/Lesson Plans/Private/PPL3.1 Flying the Traffic Pattern and Go-Arounds.md
+++ b/Lesson Plans/Private/PPL3.1 Flying the Traffic Pattern and Go-Arounds.md
@@ -149,8 +149,8 @@ Client must demonstrate proficiency at planning and flying pattern approaches an
 > - For go-around, apply takeoff power immediately and transition to climb pitch attitude for [[Vx]] or [[Vx]] as appropriate +10/-5 knots.
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]]: 
-- Go-arounds
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(15) Go-arounds
 
 ### Required Homework
 - [ ] Memorize power settings/airspeeds for pattern

--- a/Lesson Plans/Private/PPL3.2 Normal and Crosswind Approaches and Landings.md
+++ b/Lesson Plans/Private/PPL3.2 Normal and Crosswind Approaches and Landings.md
@@ -101,10 +101,12 @@ Learner must become proficient at flying stabilized approaches to landing, with 
 > Land within 400' of specified point; parallel, on centerline, nose up, no drift
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]] and [[FAR 61.107 PPL Flight Reqs]]: 
-- Landings, including normal and crosswind
-- Collision avoidance, windshear avoidance, and wake turbulence avoidance
-- Takeoffs, landings, and go-arounds
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(3) Landings^[Takeoffs covered in [[PPL1.4 Normal and Crosswind Takeoffs and Climbs]]], including normal and crosswind
+- (d)(7) Collision avoidance, windshear avoidance, and wake turbulence avoidance
+
+[[FAR 61.107 PPL Flight Reqs]]
+- (b)(1)(iv) Takeoffs, landings, and go-arounds
 
 ### Required Homework
 - [ ] Read [[FAA P-8740-40 Wind Shear]]

--- a/Lesson Plans/Private/PPL3.3 Forward Slips and No Flap Landings.md
+++ b/Lesson Plans/Private/PPL3.3 Forward Slips and No Flap Landings.md
@@ -62,8 +62,8 @@ Client must demonstrate smooth entry into a forward slip, with upwind wing down,
 > **Forward slip**: Land within 400' of specified point; parallel, on centerline, nose up, no drift
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]]: 
-- Slips to a landing
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(14) Slips to a landing
 
 ### Required Homework
 None

--- a/Lesson Plans/Private/PPL3.4 Emergency Landings.md
+++ b/Lesson Plans/Private/PPL3.4 Emergency Landings.md
@@ -81,9 +81,9 @@ Develop knowledge and skills associated with emergency landings, including choos
 Client should develop knowledge of emergencies and procedures, and demonstrate the ability to maneuver and land the airplane, while following checklist procedures including emergency communications.
 
 ### Required Logbook Phraseology
-For [[FAR 61.87 Student Solo Reqs]]: 
-- Emergency procedures and equipment malfunctions
-- Approaches to a landing area with simulated engine malfunctions
+[[FAR 61.87 Student Solo Reqs]]: 
+- (d)(11) Emergency procedures and equipment malfunctions
+- (d)(13) Approaches to a landing area with simulated engine malfunctions
 
 ### Required Homework
 - [ ] Memorize [[Vg]]

--- a/Lesson Plans/Private/PPL3.5 Short- and Soft-Field Takeoffs and Landings.md
+++ b/Lesson Plans/Private/PPL3.5 Short- and Soft-Field Takeoffs and Landings.md
@@ -72,9 +72,9 @@ Client should demonstrate ability to perform short- and soft-field takeoffs and 
 > - **Soft Field Landing**: Minimum sink, parallel, centerline, nose up, no drift; elevator back through exit
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]]:
-- Climbs at best angle and best rate
-- Takeoff, approach, and landing procedures, including short-field, soft-field, and crosswind takeoffs, approaches, and landings
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(11) Climbs at best angle and best rate
+- (e)(10) Takeoff, approach, and landing procedures, including short-field, soft-field, and crosswind takeoffs, approaches, and landings
 
 ### Required Homework
 - [ ] Complete solo quiz

--- a/Lesson Plans/Private/PPL4.2 Advanced Airport Operations.md
+++ b/Lesson Plans/Private/PPL4.2 Advanced Airport Operations.md
@@ -79,12 +79,14 @@ Ground 2 hours, 1 hour sim/flight
 Client should demonstrate knowledge of non-towered airport operations, including obtaining pre-flight information, airport markings, traffic pattern procedures, radio communications, and awareness of other aircraft.
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]] and [[FAR 61.105 PPL Knowledge Reqs]]:
-- Traffic pattern procedures that include area departure, area arrival, entry into the traffic pattern, and approach
-- Use of radios for VFR navigation and two-way communication
-- Procedures and operating practices for collision avoidance, wake turbulence precautions, and windshear avoidance
-- Use of the applicable portions of the “Aeronautical Information Manual” and FAA advisory circulars
-- Safe and efficient operation of aircraft, including collision avoidance, and recognition and avoidance of wake turbulence
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(5) Traffic pattern procedures that include area departure, area arrival, entry into the traffic pattern, and approach
+- (e)(6) Procedures and operating practices for collision avoidance, wake turbulence precautions, and windshear avoidance
+- (e)(9) Use of radios for VFR navigation and two-way communication
+
+[[FAR 61.105 PPL Knowledge Reqs]]
+- (b)(3) Use of the applicable portions of the “Aeronautical Information Manual” and FAA advisory circulars
+- (b)(7) Safe and efficient operation of aircraft, including collision avoidance, and recognition and avoidance of wake turbulence
 
 ### Required Homework
 - [ ] Read [[AC 90-66]]

--- a/Lesson Plans/Private/PPL4.3 Flight Planning, Navigation Systems, and Other XC Equipment.md
+++ b/Lesson Plans/Private/PPL4.3 Flight Planning, Navigation Systems, and Other XC Equipment.md
@@ -49,11 +49,15 @@ Ground 2 hours, 1 hour sim
 Client should develop knowledge of navigation equipment on board their training aircraft. Client should be familiar with services available from ATC, and know how and when to request assistance.
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]], [[FAR 61.105 PPL Knowledge Reqs]], and [[FAR 61.107 PPL Flight Reqs]]:
-- Procedures for operating the instruments and equipment installed in the aircraft to be flown, including recognition and use of the proper operational procedures and indications
-- Recognition, avoidance, and operational restrictions of hazardous terrain features in the geographical area where the cross-country flight will be flown
-- Use of aeronautical charts for VFR navigation using pilotage, dead reckoning, and navigation systems
-- Navigation
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(8) Procedures for operating the instruments and equipment installed in the aircraft to be flown, including recognition and use of the proper operational procedures and indications
+- (e)(7) Recognition, avoidance, and operational restrictions of hazardous terrain features in the geographical area where the cross-country flight will be flown
+
+[[FAR 61.105 PPL Knowledge Reqs]]:
+- (b)(4) Use of aeronautical charts for VFR navigation using pilotage, dead reckoning, and navigation systems
+
+[[FAR 61.107 PPL Flight Reqs]]:
+- (b)(1)(vii) Navigation
 
 ### Required Homework
 None

--- a/Lesson Plans/Private/PPL4.4 Aircraft Performance and Weight+Balance.md
+++ b/Lesson Plans/Private/PPL4.4 Aircraft Performance and Weight+Balance.md
@@ -54,10 +54,12 @@ Develop understanding of aircraft limitations and weight & balance, and how to c
 	7. [[Personal Minimums]] and other safety factor considerations 
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]] and [[FAR 61.105 PPL Knowledge Reqs]]:
-- Use of aircraft performance charts pertaining to cross-country flight
-- Effects of density altitude on takeoff and climb performance
-- Weight and balance computations
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(2) Use of aircraft performance charts pertaining to cross-country flight
+
+[[FAR 61.105 PPL Knowledge Reqs]]:
+- (b)(8) Effects of density altitude on takeoff and climb performance
+- (b)(9) Weight and balance computations
 
 ### Completion Standards
 Client should develop knowledge of [[POH]]/[[AFM]] organization, including performance and weight & balance calculations.

--- a/Lesson Plans/Private/PPL4.5 Advanced Weather Briefs and Preflight Planning.md
+++ b/Lesson Plans/Private/PPL4.5 Advanced Weather Briefs and Preflight Planning.md
@@ -64,10 +64,12 @@ Ground 1.5 hour, practice on multiple flights
 Learner should develop working knowledge of weather theory, and understand sources of weather information for pre-flight planning.
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]] and [[FAR 61.105 PPL Knowledge Reqs]]:
-- Procurement and analysis of aeronautical weather reports and forecasts, including recognition of critical weather situations and estimating visibility while in flight
-- Recognition of critical weather situations from the ground and in flight, windshear avoidance, and the procurement and use of aeronautical weather reports and forecasts
-- Preflight action that includes—
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(3) Procurement and analysis of aeronautical weather reports and forecasts, including recognition of critical weather situations and estimating visibility while in flight
+
+[[FAR 61.105 PPL Knowledge Reqs]]:
+- (b)(6) Recognition of critical weather situations from the ground and in flight, windshear avoidance, and the procurement and use of aeronautical weather reports and forecasts
+- (b)(13) Preflight action that includes—
 	- How to obtain information on runway lengths at airports of intended use, data on takeoff and landing distances, weather reports and forecasts, and fuel requirements; and
 	- How to plan for alternatives if the planned flight cannot be completed or delays are encountered.
 

--- a/Lesson Plans/Private/PPL4.6 Pilotage and Dead Reckoning.md
+++ b/Lesson Plans/Private/PPL4.6 Pilotage and Dead Reckoning.md
@@ -62,8 +62,8 @@ Client should be able to complete a navlog and fly a cross country route, using 
 > - Update the navigation plan in-flight to account for variations in heading and groundspeed due to unforecasted winds.
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]]:
-- Use of aeronautical charts for VFR navigation using pilotage and dead reckoning with the aid of a magnetic compass
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(1) Use of aeronautical charts for VFR navigation using pilotage and dead reckoning with the aid of a magnetic compass
 
 ### Required Homework
 - [ ] Complete a full navlog from Palo Alto to a destination assigned by the instructor.

--- a/Lesson Plans/Private/PPL4.7 Making the Go-No-Go Decision.md
+++ b/Lesson Plans/Private/PPL4.7 Making the Go-No-Go Decision.md
@@ -45,7 +45,7 @@ Learner completes a full navlog for a cross-country trip, and makes a wise and i
 
 ### Required Logbook Phraseology
 For [[FAR 61.105 PPL Knowledge Reqs]]:
-- Aeronautical decision making and judgment
+- (b)(12) Aeronautical decision making and judgment
 
 ### Required Homework
 - [ ]  Create your [[personal minimums]]

--- a/Lesson Plans/Private/PPL5.1 Emergency Flight by Instruments - Four Fundamentals.md
+++ b/Lesson Plans/Private/PPL5.1 Emergency Flight by Instruments - Four Fundamentals.md
@@ -55,9 +55,11 @@ Client must demonstrate basic attitude instrument flying skills, to ACS standard
 > ±200', heading ±20°, airspeed ±10 knots
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]] and [[FAR 61.107 PPL Flight Reqs]]:
-- Control and maneuvering solely by reference to flight instruments, including straight and level flight, turns, descents, climbs, use of radio aids, and ATC directives
-- Basic instrument maneuvers
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(12) Control and maneuvering solely by reference to flight instruments, including straight and level flight, turns, descents, climbs, use of radio aids, and ATC directives
+
+[[FAR 61.107 PPL Flight Reqs]]
+- (b)(1)(ix) Basic instrument maneuvers
 
 ### Required Homework
  None

--- a/Lesson Plans/Private/PPL5.3 Emergency Operations.md
+++ b/Lesson Plans/Private/PPL5.3 Emergency Operations.md
@@ -166,9 +166,11 @@ Client demonstrates appropriate knowledge of aircraft systems, abnormal and emer
 > - Level off at specified alt ±100'
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]] and [[FAR 61.107 PPL Flight Reqs]]:
-- Emergency procedures^[Also in [[PPL5.4 Lost Procedures and Diversion to Alternates]]]
-- Emergency operations
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(4) Emergency procedures^[Also in [[PPL5.4 Lost Procedures and Diversion to Alternates]]]
+
+[[FAR 61.107 PPL Flight Reqs]]:
+- (b)(1)(x) Emergency operations
 
 ### Required Homework
 - [ ] Memorize emergency flows (you may wish to reserve an aircraft and practice on the ground, although a picture also works)

--- a/Lesson Plans/Private/PPL5.4 Lost Procedures and Diversion to Alternates.md
+++ b/Lesson Plans/Private/PPL5.4 Lost Procedures and Diversion to Alternates.md
@@ -74,8 +74,8 @@ Client should be able to use multiple means to identify location, and to plan ro
 > - alt ±200'; hdg ±15°
 
 ### Required Logbook Phraseology
-For [[FAR 61.93 Solo XC Reqs]]:
-- Emergency procedures^[Also in [[PPL5.3 Emergency Operations]]]
+[[FAR 61.93 Solo XC Reqs]]:
+- (e)(4) Emergency procedures^[Also in [[PPL5.3 Emergency Operations]]]
 
 ### Required Homework
 - [ ] Schedule pre-solo xc phase check, if required

--- a/Lesson Plans/Private/PPL6.1 Night Operations and Night Cross Country.md
+++ b/Lesson Plans/Private/PPL6.1 Night Operations and Night Cross Country.md
@@ -65,8 +65,8 @@ Ground 1 hour, flight 3 hours
 Client demonstrates the knowledge and skills to fly and navigate at night safely.
 
 ### Required Logbook Phraseology
-For [[FAR 61.107 PPL Flight Reqs]]:
-- Night operations
+[[FAR 61.107 PPL Flight Reqs]]:
+- (b)(1)(xi) Night operations
 
 > [!note] 
 > Specific night flight requirements from [[FAR 61.109 PPL Experience Reqs]]:


### PR DESCRIPTION
I spent some time cross-referencing to make sure all the required logbook phrases were in one lesson or another, and decided to make those connections more clear by referencing specific FAR line items.