### PR TITLE
Update/Rearrange 172S GAIT IAP values

### DIFF
--- a/Media/Aircraft/C172S/C172S GAIT.md
+++ b/Media/Aircraft/C172S/C172S GAIT.md
@@ -16,6 +16,7 @@ data: "[[C172S Datasheet]]"
 | 🌫️ IAF Inbound Descent  |                                  |   \-2°    |               1700                |                 90                  |     \-800     |
 | 🌫️ Prec Appr to DA      |               10°                |   \-3°    |               1900                |                 90                  |     \-450     |
 | 🌫️ Non-Prec Appr to MDA |               10°                |   \-4°    |               1500                |                 90                  |     \-800     |
+| 🌫️ Level at MDA         |               10°                |    +1°    |               2300                |                 90                  |       0       |
 | 🛬 Downwind             |                                  |    TBD    | `=this.data.pattern-downwind-rpm` | `=this.data.pattern-downwind-speed` |       0       |
 | 🛬 Abeam Numbers        | `=this.data.pattern-abeam-flaps` |    TBD    |  `=this.data.pattern-abeam-rpm`   |  `=this.data.pattern-abeam-speed`   |      TBD      |
 | 🛬 Base                 | `=this.data.pattern-base-flaps`  |    TBD    |   `=this.data.pattern-base-rpm`   |   `=this.data.pattern-base-speed`   |      TBD      |

--- a/Media/Aircraft/C172S/C172S GAIT.md
+++ b/Media/Aircraft/C172S/C172S GAIT.md
@@ -30,7 +30,6 @@ data: "[[C172S Datasheet]]"
 
 | Topic         | Details                                                    |
 | ------------- |:---------------------------------------------------------- |
-| [[CDFA]]      | [[AC 120-108]]                                             |
 | Leaning       | 50° ROP when above 3000'                                   |
 | V<sub>A</sub> | `= this.data.Va-mgw` @ max; 98@2200lb; 90@1900lb |
 | Short T.O.    | (short-takeoff-flaps::10°) Flaps, {*Rotate*, *50ft*}@*weight*:<br>{51,56}@`=this.data.mgw`lb; {48,54}@2400lb; {44,50}@2200lb                                   |

--- a/Media/Aircraft/C172S/C172S GAIT.md
+++ b/Media/Aircraft/C172S/C172S GAIT.md
@@ -17,7 +17,7 @@ data: "[[C172S Datasheet]]"
 | Abeam Numbers                  | `=this.data.pattern-abeam-flaps` |    TBD    |  `=this.data.pattern-abeam-rpm`   |  `=this.data.pattern-abeam-speed`   |      TBD      |
 | Base                           | `=this.data.pattern-base-flaps`  |    TBD    |   `=this.data.pattern-base-rpm`   |   `=this.data.pattern-base-speed`   |      TBD      |
 | Final                          | `=this.data.pattern-final-flaps` |    TBD    |  `=this.data.pattern-final-rpm`   |         `= this.data.vref`          |      TBD      |
-| **🌫️ IAP - Precision and CDFA** |                                  |           |                                   |                                     |               |
+| **🌫️ IAP - Precision and [[CDFA]]** |                               |           |                                   |                                     |               |
 | ↘ Clean                        |                                  |   \-1°    |               1800                |                 90                  |     \-500     |
 | ↘ Configured                   |               10°                |   \-3°    |               1900                |                 90                  |     \-500     |
 | **🌫️ IAP - Step-Down**        |                                  |           |                                   |                                     |               |
@@ -30,6 +30,7 @@ data: "[[C172S Datasheet]]"
 
 | Topic         | Details                                                    |
 | ------------- |:---------------------------------------------------------- |
+| [[CDFA]]      | [[AC 120-108]]                                             |
 | Leaning       | 50° ROP when above 3000'                                   |
 | V<sub>A</sub> | `= this.data.Va-mgw` @ max; 98@2200lb; 90@1900lb |
 | Short T.O.    | (short-takeoff-flaps::10°) Flaps, {*Rotate*, *50ft*}@*weight*:<br>{51,56}@`=this.data.mgw`lb; {48,54}@2400lb; {44,50}@2200lb                                   |

--- a/Media/Aircraft/C172S/C172S GAIT.md
+++ b/Media/Aircraft/C172S/C172S GAIT.md
@@ -3,24 +3,28 @@ tags: [gait]
 data: "[[C172S Datasheet]]"
 ---
 
-| **C172S Gaits** v1.1   |            **Flaps**             | **Pitch** |              **RPM**              |            **IAS (kts)**            | **VSI (fpm)** |
-| ----------------------- |:--------------------------------:|:---------:|:---------------------------------:|:-----------------------------------:|:-------------:|
-| ⚠️ V<sub>G</sub>        |                                  |    TBD    |               idle                |          `= this.data.Vg`           |      TBD      |
-| 🛫 V<sub>R</sub>        |                                  |    TBD    |                max                |                 55                  |      TBD      |
-| V<sub>X</sub>           |                                  |    TBD    |                max                |          `= this.data.Vx`           |      TBD      |
-| 🛫 V<sub>Y</sub>        |                                  |   +10°    |                max                |          `= this.data.vy`           |     +600      |
-| 🛫 V<sub>Climb</sub>    |                                  |    +5°    |                max                |                 90                  |     +500      |
-| Cruise                  |                                  |    0°     |               2500                |                 105                 |       0       |
-| Cruise Descent          |                                  |  \-2.5°   |               2500                |                 115                 |     \-500     |
-| 🌫️ IAF Inbound Level    |                                  |    +2°    |               2200                |                 90                  |       0       |
-| 🌫️ IAF Inbound Descent  |                                  |   \-2°    |               1700                |                 90                  |     \-800     |
-| 🌫️ Prec Appr to DA      |               10°                |   \-3°    |               1900                |                 90                  |     \-450     |
-| 🌫️ Non-Prec Appr to MDA |               10°                |   \-4°    |               1500                |                 90                  |     \-800     |
-| 🌫️ Level at MDA         |               10°                |    +1°    |               2300                |                 90                  |       0       |
-| 🛬 Downwind             |                                  |    TBD    | `=this.data.pattern-downwind-rpm` | `=this.data.pattern-downwind-speed` |       0       |
-| 🛬 Abeam Numbers        | `=this.data.pattern-abeam-flaps` |    TBD    |  `=this.data.pattern-abeam-rpm`   |  `=this.data.pattern-abeam-speed`   |      TBD      |
-| 🛬 Base                 | `=this.data.pattern-base-flaps`  |    TBD    |   `=this.data.pattern-base-rpm`   |   `=this.data.pattern-base-speed`   |      TBD      |
-| 🛬 Final                | `=this.data.pattern-final-flaps` |    TBD    |  `=this.data.pattern-final-rpm`   |         `= this.data.vref`          |      TBD      |
+| **C172S Gaits** v1.2          |            **Flaps**             | **Pitch** |              **RPM**              |            **IAS (kts)**            | **VSI (fpm)** |
+| ------------------------------ |:--------------------------------:|:---------:|:---------------------------------:|:-----------------------------------:|:-------------:|
+| ⚠️ V<sub>G</sub>               |                                  |    TBD    |               idle                |          `= this.data.Vg`           |      TBD      |
+| 🛫 V<sub>R</sub>               |                                  |    TBD    |                max                |                 55                  |      TBD      |
+| V<sub>X</sub>                  |                                  |    TBD    |                max                |          `= this.data.Vx`           |      TBD      |
+| 🛫 V<sub>Y</sub>               |                                  |   +10°    |                max                |          `= this.data.vy`           |     +600      |
+| 🛫 V<sub>Climb</sub>           |                                  |    +5°    |                max                |                 90                  |     +500      |
+| Cruise                         |                                  |    0°     |               2500                |                 105                 |       0       |
+| Cruise Descent                 |                                  |  \-2.5°   |               2500                |                 115                 |     \-500     |
+| **🛬 Pattern**                 |                                  |           |                                   |                                     |               |
+| Downwind                       |                                  |    TBD    | `=this.data.pattern-downwind-rpm` | `=this.data.pattern-downwind-speed` |       0       |
+| Abeam Numbers                  | `=this.data.pattern-abeam-flaps` |    TBD    |  `=this.data.pattern-abeam-rpm`   |  `=this.data.pattern-abeam-speed`   |      TBD      |
+| Base                           | `=this.data.pattern-base-flaps`  |    TBD    |   `=this.data.pattern-base-rpm`   |   `=this.data.pattern-base-speed`   |      TBD      |
+| Final                          | `=this.data.pattern-final-flaps` |    TBD    |  `=this.data.pattern-final-rpm`   |         `= this.data.vref`          |      TBD      |
+| **🌫️ IAP - Precision and CDFA** |                                  |           |                                   |                                     |               |
+| ↘ Clean                        |                                  |   \-1°    |               1800                |                 90                  |     \-500     |
+| ↘ Configured                   |               10°                |   \-3°    |               1900                |                 90                  |     \-500     |
+| **🌫️ IAP - Step-Down**        |                                  |           |                                   |                                     |               |
+| ↓ Dive - Clean                 |                                  |   \-2°    |               1700                |                 90                  |     \-800     |
+| ➡ Drive - Clean                |                                  |    +2°    |               2200                |                 90                  |       0       |
+| ↓ Dive - Configured            |               10°                |   \-4°    |               1500                |                 90                  |     \-800     |
+| ➡ Drive - Configured           |               10°                |    +1°    |               2300                |                 90                  |       0       |
 
 <br>
 


### PR DESCRIPTION
Give me a sanity-check on the IAP organization and values.

I was looking for numbers for my own in-flight guide and came to this page. I thought the IAP labels were too prescriptive (I might use the dirty-0FPM row at the MDA _or_ while driving to ZOTPI) but then I created a whole prescriptive system of my own...and now I'm doubting myself. I'll measure the actual values on Thursday but I'd love your thoughts.

The "dive" rows (both on the main branch and this branch) have the dirty configuration taking less power (1500) than the clean dive (1700) while holding the same KIAS and FPM, which seems fishy.